### PR TITLE
Support timezone for hour and minute

### DIFF
--- a/src/__tests__/format-test.js
+++ b/src/__tests__/format-test.js
@@ -48,12 +48,22 @@ describe('Formatting dates', () => {
     ).toEqual('09:09:09 fm')
   })
   it('should support both HH and hh', () => {
-    expect(format(new Date('2022-11-16T15:03:00.000Z'), 'HH', {timeZone: 'Europe/Stockholm'})).toEqual('16')
-    expect(format(new Date('2022-11-16T15:03:00.000Z'), 'hh', {timeZone: 'Europe/Stockholm'})).toEqual('04')
+    expect(
+      format(new Date('2022-11-16T15:03:00.000Z'), 'HH', {timeZone: 'Europe/Stockholm'})
+    ).toEqual('16')
+    expect(
+      format(new Date('2022-11-16T15:03:00.000Z'), 'hh', {timeZone: 'Europe/Stockholm'})
+    ).toEqual('04')
   })
   it('should care about timezone', () => {
-    expect(format(new Date('2022-11-16T22:20:00.000Z'), 'yyyy-MM-dd HH:mm', {timeZone: 'Europe/Stockholm'})).toEqual('2022-11-16 23:20')
-    expect(format(new Date('2022-11-16T22:20:00.000Z'), 'yyyy-MM-dd HH:mm', {timeZone: 'Asia/Tbilisi'})).toEqual('2022-11-17 02:20')
-    expect(format(new Date('2022-11-16T22:20:00.000Z'), 'yyyy-MM-dd HH:mm', {timeZone: 'America/St_Johns'})).toEqual('2022-11-16 18:50')
+    expect(
+      format(new Date('2022-11-16T22:20:00.000Z'), 'yyyy-MM-dd HH:mm', {timeZone: 'Europe/Stockholm'})
+    ).toEqual('2022-11-16 23:20')
+    expect(
+      format(new Date('2022-11-16T22:20:00.000Z'), 'yyyy-MM-dd HH:mm', {timeZone: 'Asia/Tbilisi'})
+    ).toEqual('2022-11-17 02:20')
+    expect(
+      format(new Date('2022-11-16T22:20:00.000Z'), 'yyyy-MM-dd HH:mm', {timeZone: 'America/St_Johns'})
+    ).toEqual('2022-11-16 18:50')
   })
 })

--- a/src/__tests__/format-test.js
+++ b/src/__tests__/format-test.js
@@ -47,4 +47,13 @@ describe('Formatting dates', () => {
       format(new Date(2021, 3, 3, 9, 9, 9), 'hh:mm:ss a', { locale: 'sv-SE' })
     ).toEqual('09:09:09 fm')
   })
+  it('should support both HH and hh', () => {
+    expect(format(new Date('2022-11-16T15:03:00.000Z'), 'HH', {timeZone: 'Europe/Stockholm'})).toEqual('16')
+    expect(format(new Date('2022-11-16T15:03:00.000Z'), 'hh', {timeZone: 'Europe/Stockholm'})).toEqual('04')
+  })
+  it('should care about timezone', () => {
+    expect(format(new Date('2022-11-16T22:20:00.000Z'), 'yyyy-MM-dd HH:mm', {timeZone: 'Europe/Stockholm'})).toEqual('2022-11-16 23:20')
+    expect(format(new Date('2022-11-16T22:20:00.000Z'), 'yyyy-MM-dd HH:mm', {timeZone: 'Asia/Tbilisi'})).toEqual('2022-11-17 02:20')
+    expect(format(new Date('2022-11-16T22:20:00.000Z'), 'yyyy-MM-dd HH:mm', {timeZone: 'America/St_Johns'})).toEqual('2022-11-16 18:50')
+  })
 })


### PR DESCRIPTION
`Date#getHours` and `Date#getMinutes` returns hours & minutes in the local timezone instead of the timezone passed via `options.timeZone` arg. Here is a PR to fix that :)

P.S. I didn't find sizelimit or smth to count bundle size, but here's what finder says (format.js after `build:es`): 
After:
3 541 bytes
Before:
3 361 bytes
