### PR TITLE
Fix bug with "d" pattern token

### DIFF
--- a/src/__tests__/format-test.js
+++ b/src/__tests__/format-test.js
@@ -9,6 +9,7 @@ describe('Formatting dates', () => {
     expect(format(new Date('03/03/2021'), 'DDD dd-MM-yyyy')).toEqual(
       'Wednesday 03-03-2021'
     )
+    expect(format(new Date('03/03/2021'), 'MMMM d')).toEqual('March 3')
     expect(format(new Date('03/03/2021'), 'dd-0MM-yyyy')).toEqual('03-003-2021')
     expect(format(new Date('03/03/2021'), 'dd-MMM-yyyy')).toEqual('03-Mar-2021')
     expect(format(new Date('03/03/2021 11:45:21'), 'hh:mm:ss a')).toEqual(

--- a/src/format.js
+++ b/src/format.js
@@ -20,7 +20,7 @@ const optionNames = {
 const values = {
   y: ['numeric', '2-digit', undefined, 'numeric'],
   M: ['narrow', '2-digit', 'short', 'long'],
-  d: [undefined, '2-digit'],
+  d: ['numeric', '2-digit'],
   D: ['narrow', 'short', 'long'],
   S: [1, 2, 3],
   G: ['narrow', 'short', 'long'],


### PR DESCRIPTION
Output from failing test case:

```
  ● Formatting dates › should correctly format

    expect(received).toEqual(expected) // deep equality

    Expected: "March 3"
    Received: "March d"

    > 12 |     expect(format(new Date('03/03/2021'), 'MMMM d')).toEqual('March 3')
```

Thanks for making this library!